### PR TITLE
Add compatibility with rollout >= 2.2.1.

### DIFF
--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -18,7 +18,7 @@ module RolloutUi
     end
 
     def user_ids
-      rollout.get(feature_for(name)).users
+      rollout.get(feature_for(name)).users.to_a
     end
 
     def percentage=(percentage_val)


### PR DESCRIPTION
### SUMMARY:
- [Add compatibility with rollout >= 2.2.1](https://github.com/jrallison/rollout_ui/issues/35)
- Rollout is now returning a `Set` for Feature#user_ids, instead of an `Array`.  
- Rollout_ui is expecting an Array so that they can call: `<%= feature.user_ids.join(",") %>`
- Rollout_ui is not being actively maintained
